### PR TITLE
Add popperjs as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
+    "@popperjs/core": "^2.8.6",
     "bootstrap": "5.0.0-beta2"
   }
 }


### PR DESCRIPTION
Adds `@popperjs/core` as peer dependency.

Yarn v2 issues warnings if all peer dependencies are not explicitly enumerated . `bootstrap` has a peer dependency on `@popperjs/core` so this package should depend have `@popperjs/core` as a direct dependency.

This shouldn't break any existing workflow and makes package dependencies more explicit, even if you're not using `yarn`.