### PR TITLE
Fix colors of tooltips

### DIFF
--- a/scss/_variables-alt.scss
+++ b/scss/_variables-alt.scss
@@ -473,8 +473,8 @@ $accordion-button-active-icon-alt:  url("data:image/svg+xml,<svg xmlns='http://w
 // Tooltips
 // ______________________________________
 
-$tooltip-color-alt:                     $black-alt !default;
-$tooltip-bg-alt:                        $white-alt !default;
+$tooltip-color-alt:                     $white-alt !default;
+$tooltip-bg-alt:                        $black-alt !default;
 $tooltip-opacity-alt:                   .9 !default;
 
 $tooltip-arrow-color-alt:               $tooltip-bg-alt !default;


### PR DESCRIPTION
Background should be black, not white